### PR TITLE
added option to include the bin path for phpdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ In your project's Gruntfile, add a section named `phpdocumentor` to the data obj
 grunt.initConfig({
   phpdocumentor: {
     options : {
+      bin: '/different/path/to/phpdoc',
       directory : 'src/main/php/config,src/main/php/library,src/main/php/module',
       target : 'target/phpdocumentor'
     }, 
@@ -44,6 +45,12 @@ grunt.initConfig({
 ```
 
 ### Options
+
+#### options.bin( optional )
+Type: `String`
+Default value: `phpdoc`
+
+Path to the phpdoc executable, by default it will try the command itself.
 
 #### options.directory
 Type: `String`

--- a/tasks/phpdocumentor.js
+++ b/tasks/phpdocumentor.js
@@ -62,7 +62,8 @@ module.exports = function(grunt) {
             
         }
         
-        var phpDocumentorCommand = 'phpdoc';
+        // allow to specify the path for the bin, this can be used later to include the phpdoc 'phar' version with this task 
+        var phpDocumentorCommand = this.data.bin || 'phpdoc';
         
         phpDocumentorCommand += ' --target=' + options.target;
         phpDocumentorCommand += ' --directory=' + options.directory;


### PR DESCRIPTION
Sometimes phpdoc wont be installed globally. This will also help in the future in case a phpdoc.phar is added to this repo so that it can work out of the box without needing to install anything else.
