### PR TITLE
Version 0 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 > Runs the PHPDocumentor documentation generator tool.
 
-## WARNING
-This Grunt plugin and has not been tested thorougly yet so use it at your own risk ! 
+This build include phpDocumentor version 2.0.0a12, other versions can be specified by the `bin` option 
 
 For now the plugin supports only one PHPDocumentor call : ```phpdoc -d dir -t target```.
 
@@ -30,16 +29,11 @@ In your project's Gruntfile, add a section named `phpdocumentor` to the data obj
 ```js
 grunt.initConfig({
   phpdocumentor: {
-    options : {
-      bin: '/different/path/to/phpdoc',
-      directory : 'src/main/php/config,src/main/php/library,src/main/php/module',
-      target : 'target/phpdocumentor'
-    }, 
-                    
-    /**
-     * Target used to generate the PHP documentation of the project.
-     */
-    generate : {}
+    dist: {
+        bin: 'bin/phpdoc',
+        directory : './',
+        target : 'docs'
+    }                
   },
 })
 ```
@@ -50,19 +44,19 @@ grunt.initConfig({
 Type: `String`
 Default value: `phpdoc`
 
-Path to the phpdoc executable, by default it will try the command itself.
+Path to the phpdoc executable, by default it will use the one that come with task. It is located on the bin folder.
 
 #### options.directory
 Type: `String`
-Default value: `TODO`
+Default value: `./`
 
-Comma-separated list of directories to (recursively) parse (multiple values allowed)
+Comma-separated list of directories to (recursively) parse (multiple values allowed). It will default to the folder where Gruntfile is located.
 
 #### options.target
 Type: `String`
-Default value: `TODO`
+Default value: `docs`
 
-Path where to store the generated output.
+Path where to store the generated output. It will default to a folder named 'docs' 
 
 ### Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Path where to store the generated output. It will default to a folder named 'doc
 
 ### Usage Examples
 
-```grunt phpdocumentor:generate```
+```grunt phpdocumentor```
 
 ## Release History
 _(Nothing yet)_

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Default value: `phpdoc`
 
 Path to the phpdoc executable, by default it will use the one that come with task. It is located on the bin folder.
 
-#### options.directory
+#### options.directory( optional )
 Type: `String`
 Default value: `./`
 
 Comma-separated list of directories to (recursively) parse (multiple values allowed). It will default to the folder where Gruntfile is located.
 
-#### options.target
+#### options.target( optional )
 Type: `String`
 Default value: `docs`
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ In your project's Gruntfile, add a section named `phpdocumentor` to the data obj
 grunt.initConfig({
   phpdocumentor: {
     options : {
+      bin: '/different/path/to/phpdoc',
       directory : 'src/main/php/config,src/main/php/library,src/main/php/module',
       target : 'target/phpdocumentor'
     }, 
@@ -44,6 +45,12 @@ grunt.initConfig({
 ```
 
 ### Options
+
+#### options.bin( optional )
+Type: `String`
+Default value: `phpdoc`
+
+Path to the phpdoc executable, by default it will try the command itself.
 
 #### options.directory
 Type: `String`

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ Path where to store the generated output. It will default to a folder named 'doc
 ```grunt phpdocumentor```
 
 ## Release History
-_(Nothing yet)_
+0.3.0 - Including ```phpDocumentor version 2.0.0a12``` on the bin, giving default to all options

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This build include phpDocumentor version 2.0.0a12, other versions can be specified by the `bin` option 
 
-For now the plugin supports only one PHPDocumentor call : ```phpdoc -d dir -t target```.
+This plugin runs the command : ```phpdoc -d dir -t target```.
 
 ## Getting Started
 This plugin requires Grunt `~0.4.1`

--- a/bin/phpdoc
+++ b/bin/phpdoc
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# script directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PHPDOC=$DIR/phpDocumentor.phar
+PHP=$(type -p php) 
+
+# call phpdocumentator with args passed by this script using php 
+${PHP} ${PHPDOC} $@

--- a/package.json
+++ b/package.json
@@ -33,8 +33,10 @@
   "scripts": {
     "test": "grunt test"
   },
+  "dependencies": {
+    "lodash": "~1.1.1"
+  },
   "devDependencies": {
-    "lodash": "~1.1.1",
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
   "name": "grunt-phpdocumentor",
   "description": "Runs the PHPDocumentor documentation generator tool.",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/gomoob/grunt-phpdocumentor",
   "author": {
     "name": "Baptiste Gaillard",
     "email": "baptiste.gaillard@gomoob.com",
     "url": "http://www.gomoob.com"
   },
+  "contributors": [{
+    "name": "Mitermayer Reis",
+    "email": "mitermayer.reis@gmail.com",
+    "url": "http://job.mitermayer.com"
+  }],
   "repository": {
     "type": "git",
     "url": "git://github.com/gomoob/grunt-phpdocumentor"
@@ -29,6 +34,7 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "lodash": "~1.1.1",
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.1.2",

--- a/tasks/phpdocumentor.js
+++ b/tasks/phpdocumentor.js
@@ -62,7 +62,8 @@ module.exports = function(grunt) {
             
         }
         
-        var phpDocumentorCommand = 'phpdoc';
+        // allow to specify the path for the bin, this can be used later to include the phpdoc 'phar' version with this task 
+        var phpDocumentorCommand = this.data.bin || 'phpdoc';
         
         phpDocumentorCommand += ' --target=' + options.target;
         phpDocumentorCommand += ' --directory=' + options.directory;

--- a/tasks/phpdocumentor.js
+++ b/tasks/phpdocumentor.js
@@ -12,71 +12,75 @@ module.exports = function(grunt) {
 
     var ChildProcess = require('child_process'), 
         Util = require('util'), 
-        Path = require('path');
+        Path = require('path'),
+        _ = require('lodash')._;
     
     // Please see the Grunt documentation for more information regarding task
     // creation: http://gruntjs.com/creating-tasks
     grunt.registerMultiTask('phpdocumentor', 'Runs the PHPDocumentor documentation generator tool.', function() {
 
+        var options = {};
         // Merge task-specific and/or target-specific options with these defaults.
-        var options = this.options({
-            target : '',
-            filename : '',
-            directory : '',
-            encoding : '',
-            extensions : '',
-            ignore : '',
-            hidden : '',
-            'ignore-symlinks' : '',
-            markers : '',
-            title : '',
-            force : '',
-            validate : '',
-            visibility : '',
-            defaultpackagename : '',
-            sourcecode : '',
-            progressbar : '',
-            template : '',
-            parseprivate : '',
-            config : ''
-        });
+        _.extend(options, {
+                target : '',
+                filename : '',
+                directory : '',
+                encoding : '',
+                extensions : '',
+                ignore : '',
+                hidden : '',
+                'ignore-symlinks' : '',
+                markers : '',
+                title : '',
+                force : '',
+                validate : '',
+                visibility : '',
+                defaultpackagename : '',
+                sourcecode : '',
+                progressbar : '',
+                template : '',
+                parseprivate : '',
+                config : ''
+            },
+            this.data
+        );
         
         var done = this.async();
         
         // Checks if the provided Phpdocumentor command name is valid
-        if(this.data.command !== undefined &&
-           this.data.command !== 'help' && 
-           this.data.command !== 'list' && 
-           this.data.command !== 'parse' && 
-           this.data.command !== 'run' && 
-           this.data.command !== 'transform' &&
-           this.data.command !== 'project:parse' && 
-           this.data.command !== 'project:run' && 
-           this.data.command !== 'project:transform' &&
-           this.data.command !== 'template:generate' && 
-           this.data.command !== 'template:list' && 
-           this.data.command !== 'template:package') {
+        if(options.command !== undefined &&
+           options.command !== 'help' && 
+           options.command !== 'list' && 
+           options.command !== 'parse' && 
+           options.command !== 'run' && 
+           options.command !== 'transform' &&
+           options.command !== 'project:parse' && 
+           options.command !== 'project:run' && 
+           options.command !== 'project:transform' &&
+           options.command !== 'template:generate' && 
+           options.command !== 'template:list' && 
+           options.command !== 'template:package') {
             
             grunt.log.error(Util.format('Phpdocumentor does not provide any command named \'%s\' !', this.data.command));
             done(false);
             
         }
         
-        // allow to specify the path for the bin, this can be used later to include the phpdoc 'phar' version with this task 
-        var phpDocumentorCommand = this.data.bin || 'phpdoc';
-        
-        phpDocumentorCommand += ' --target=' + options.target;
-        phpDocumentorCommand += ' --directory=' + options.directory;
+        // path to the phar file
+        var phpDocumentorCommand = options.bin        || Path.resolve(__dirname, '..', 'bin', 'phpdoc'),
+            target               = options.target     || 'docs',
+            directory            = options.directory  || './';
+
+        phpDocumentorCommand += ' --target=' + target;
+        phpDocumentorCommand += ' --directory=' + directory;
         
         grunt.log.write(phpDocumentorCommand);
         
         var childProcess = ChildProcess.exec(phpDocumentorCommand, function(error, stdout, stderr) {
             
-            grunt.log.writeln();
             grunt.log.writeln(error);
             grunt.log.writeln(stdout);
             grunt.log.writeln(stderr);
-        
         });
         
         childProcess.on('exit', function(code) {


### PR DESCRIPTION
Fixed options on task, included `phpDocumentator.phar` to bin folder and created a bash script to pass args to it since the current version of the `phpDocumentator.phar` doesnt come with `#!/usr/bin/env php` directive, and if trying to add manually simply breaks the file. Fully tested and working as expected. Also added myself on the package.json as contributor , hope you dont mind. We have a big project on our organization and would like to include this task on it. Hope to get this merged and up and runing on npm soon.

kind regards,
mitermayer

:)
